### PR TITLE
Bugfix device sync

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -167,6 +167,7 @@ const fields = [
   'status',
   'targetName',
   'timeframes',
+  'provider',
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtoolbox",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "A Node JS package for interacting with xMatters. Contains functions to interact with xMatters APIs or perform a synchronization, create events, libraries to convert data, and much much more!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds provider into syncing for devices. This fixes an issue identified here: https://github.com/xmatters/xmtoolbox-quick-start/issues/12

The problem is when an xMatters instance has multiple voice providers defined, the API call must include which provider to use.